### PR TITLE
Add backend and frontend skeleton for simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,30 @@ Deployment and Community:
 Deploy the simulation on a scalable cloud platform, accessible to users worldwide.
 Create a vibrant community of users to share insights, collaborate on projects, and contribute to the development of the simulation.
 Provide ongoing support and updates to the simulation.
+
+## Local Development
+
+### Backend
+1. Install Python 3.10+ and `pip`.
+2. Install dependencies:
+   ```bash
+   pip install fastapi uvicorn pydantic
+   ```
+3. Start the API server:
+   ```bash
+   uvicorn backend.main:app --reload
+   ```
+
+### Frontend
+1. Install Node.js 16 or later.
+2. Install packages:
+   ```bash
+   cd frontend && npm install
+   ```
+3. Launch the minimal UI:
+   ```bash
+   npm start
+   ```
+
+### Configuration
+Update `backend/config.py` with your own API keys and database information.

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,5 @@
+class Config:
+    """Configuration placeholders."""
+    FACE_API_KEY = "YOUR_FACE_API_KEY"
+    DATABASE_URL = "DATABASE_URL"
+    WORLD_SEED = "WORLD_SEED"

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,51 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+from .config import Config
+import random
+
+app = FastAPI(title="TheFramework World")
+
+class Persona(BaseModel):
+    id: int
+    name: str
+    gender: str
+    age: int
+    profession: str
+    face_model: str
+
+class WorldTracker(BaseModel):
+    population: int
+    tick: int
+
+db: List[Persona] = []
+tracker = WorldTracker(population=0, tick=0)
+
+@app.post("/person", response_model=Persona)
+def create_person(name: str, gender: str, age: int, profession: str):
+    """Create a new persona with a placeholder 3D face."""
+    pid = len(db) + 1
+    face_model = generate_face(gender, age, profession)
+    persona = Persona(id=pid, name=name, gender=gender, age=age, profession=profession, face_model=face_model)
+    db.append(persona)
+    tracker.population = len(db)
+    return persona
+
+@app.get("/people", response_model=List[Persona])
+def list_people():
+    return db
+
+@app.get("/tracker", response_model=WorldTracker)
+def get_tracker():
+    return tracker
+
+@app.post("/tick")
+def advance_tick():
+    tracker.tick += 1
+    return tracker
+
+def generate_face(gender: str, age: int, profession: str) -> str:
+    """Placeholder for 3D face generation."""
+    # Actual implementation would use Config.FACE_API_KEY
+    hash_seed = f"{gender}-{age}-{profession}-{random.randint(0,9999)}"
+    return f"faces/{hash_seed}.glb"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "theframework-ui",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "node-fetch": "^3.3.1"
+  },
+  "scripts": {
+    "start": "node src/index.js"
+  }
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,9 @@
+const fetch = require('node-fetch');
+
+async function main() {
+  const res = await fetch('http://localhost:8000/tracker');
+  const tracker = await res.json();
+  console.log('World tracker:', tracker);
+}
+
+main();


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with persona creation and world tracker
- add config placeholders for API keys
- provide minimal Node-based frontend
- update README with instructions for running backend and frontend

## Testing
- `python -m py_compile backend/*.py`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6843613753548324a2d8616839f2e8ab